### PR TITLE
Cleanup formatting using golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+on: [pull_request]
+
+env:
+  GO111MODULE: on
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: GolangCI-Lint
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15.0'
+      - name: Get golangci-lint
+        run: go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Lint
+        run: golangci-lint run -v --out-format github-actions

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,73 @@
+linters:
+  disable-all: true
+  enable:
+    - asciicheck       # Check for non-ASCII identifiers
+    - bodyclose        # Checks whether HTTP response body is closed successfully
+    - deadcode         # Finds unused code
+    - dogsled          # Checks assignments with too many blank identifiers
+    - dupl             # Code clone detection
+    - errcheck         # Checking for unchecked errors
+    - exhaustive       # Check exhaustiveness of enum switch statements
+    - exportloopref    # Checks for pointers to enclosing loop variables
+    - funlen           # Detection of long functions
+    - gochecknoglobals # Checks that no globals are present
+    - gochecknoinits   # Checks that no init functions are present in Go code
+    - gocognit         # Computes and checks the cognitive complexity of functions
+    - goconst          # Finds repeated strings that could be replaced by a constant
+    - gocritic         # The most opinionated Go source code linter
+    - gocyclo          # Computes and checks the cyclomatic complexity of functions
+    - godot            # Check if comments end in a period
+    - godox            # Detection of FIXME, TODO and other comment keywords
+    - goerr113         # Check error handling expressions
+    - gofmt            # Checks whether code was gofmt-ed
+    - golint           # Prints out style mistakes
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
+    - gosec            # Inspects source code for security problems
+    - gosimple         # Specializes in simplifying code
+    - govet            # Reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign      # Detects when assignments to existing variables are not used
+    - interfacer       # Suggests narrower interface types
+    - maligned         # Detect Go structs that would take less memory if their fields were sorted
+    - misspell         # Finds commonly misspelled English words in comments
+    - nakedret         # Finds naked returns in functions greater than a specified function length
+    - nestif           # Reports deeply nested if statements
+    - nlreturn         # Checks for a new line before return and branch statements
+    - nolintlint       # Reports ill-formed or insufficient nolint directives
+    - prealloc         # Finds slice declarations that could potentially be preallocated
+    - rowserrcheck     # Checks whether err of rows is checked successfully
+    - scopelint        # Checks for unpinned variables in go programs
+    - staticcheck      # Go vet on steroids, applying a ton of static analysis checks
+    - structcheck      # Finds unused struct fields
+    - testpackage      # Makes you use a separate _test package
+    - typecheck        # Like the front-end of a Go compiler, parses and type-checks Go code
+    - unconvert        # Remove unnecessary type conversions
+    - unparam          # Reports unused function parameters
+    - unused           # Checks for unused constants, variables, functions and types
+    - varcheck         # Finds unused global variables and constants
+    - whitespace       # Detection of leading and trailing whitespace
+    - wsl              # Whitespace Linter - Forces you to use empty lines!
+    #- depguard         # Checks if package imports are in a list of acceptable packages
+    #- gci              # Control package import order and make it always deterministic
+    #- gofumpt          # Checks whether code was gofumpt-ed
+    #- goheader         # Checks if file header matches to pattern
+    #- goimports        # Does everything that gofmt does and checks unused imports
+    #- gomnd            # An analyzer to detect magic numbers
+    #- gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    #- lll              # Reports long lines
+    #- noctx            # Finds sending HTTP request without context.Context
+    #- sqlclosecheck    # Checks that sql.Rows and sql.Stmt are closed.
+    #- stylecheck       # Replacement for golint
+
+issues:
+  include:
+    - EXC0002
+    - EXC0005
+
+linters-settings:
+  maligned:
+    suggest-new: true
+  nolintlint:
+    allow-unused: false
+    allow-leading-space: false
+    require-explanation: true
+    require-specific: true

--- a/db.go
+++ b/db.go
@@ -109,7 +109,7 @@ func (db *Database) Get(key string, id string, args ...string) (r *Response, err
 
 	r, err = db.runcmd("GET", cmdargs...)
 	if err != nil {
-		if err.Error() == "id not found" {
+		if err.Error() == "received error: id not found" {
 			return nil, nil
 		}
 

--- a/db.go
+++ b/db.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Collin Kreklow
+// Copyright 2020 Collin Kreklow
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,6 +24,7 @@ package t38c
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"strconv"
 
@@ -33,6 +34,7 @@ import (
 var (
 	errUninitialized = errors.New("database not initialized")
 	errArgs          = errors.New("invalid arguments")
+	errResponse      = errors.New("received error")
 )
 
 // Database is the primary object for interacting with the database.
@@ -47,10 +49,9 @@ type Database struct {
 }
 
 // Connect establishes a connection and returns a Database object.
-func Connect(server string, port string, poolsize int) (*Database, error) {
-	var err error
+func Connect(server string, port string, poolsize int) (db *Database, err error) {
+	db = new(Database)
 
-	db := new(Database)
 	db.pool, err = radix.NewPool(
 		"tcp",
 		net.JoinHostPort(server, port),
@@ -69,92 +70,98 @@ func (db *Database) Close() error {
 	if db.pool == nil {
 		return errUninitialized
 	}
+
 	return db.pool.Close()
 }
 
 // Set saves an object to the database.
-func (db *Database) Set(key string, id string, args ...string) error {
-	var err error
+func (db *Database) Set(key string, id string, args ...string) (err error) {
 	if db.pool == nil {
 		return errUninitialized
 	}
+
 	if args == nil {
 		return errArgs
 	}
 
 	cmdargs := append([]string{key, id}, args...)
+
 	_, err = db.runcmd("SET", cmdargs...)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // Get returns the requested entry as a response object, or nil if the
 // object is not found.
-func (db *Database) Get(key string, id string, args ...string) (*Response, error) {
-	var err error
+func (db *Database) Get(key string, id string, args ...string) (r *Response, err error) {
 	if db.pool == nil {
 		return nil, errUninitialized
 	}
 
 	cmdargs := []string{key, id}
+
 	if args != nil {
 		cmdargs = append(cmdargs, args...)
 	}
-	var r *Response
+
 	r, err = db.runcmd("GET", cmdargs...)
 	if err != nil {
 		if err.Error() == "id not found" {
 			return nil, nil
 		}
+
 		return nil, err
 	}
+
 	return r, nil
 }
 
 // Scan iterates through a key returning a set of results.
-func (db *Database) Scan(key string, args ...string) (*Response, error) {
-	var err error
+func (db *Database) Scan(key string, args ...string) (r *Response, err error) {
 	if db.pool == nil {
 		return nil, errUninitialized
 	}
 
 	cmdargs := []string{key}
+
 	if args != nil {
 		cmdargs = append(cmdargs, args...)
 	}
-	var r *Response
+
 	r, err = db.runcmd("SCAN", cmdargs...)
 	if err != nil {
 		return nil, err
 	}
+
 	return r, nil
 }
 
 // Search iterates through the string values of a key returning a set of
 // results.
-func (db *Database) Search(key string, args ...string) (*Response, error) {
-	var err error
+func (db *Database) Search(key string, args ...string) (r *Response, err error) {
 	if db.pool == nil {
 		return nil, errUninitialized
 	}
 
 	cmdargs := []string{key}
+
 	if args != nil {
 		cmdargs = append(cmdargs, args...)
 	}
-	var r *Response
+
 	r, err = db.runcmd("SEARCH", cmdargs...)
 	if err != nil {
 		return nil, err
 	}
+
 	return r, nil
 }
 
 // Del deletes the requested entry.
-func (db *Database) Del(key string, id string) error {
-	var err error
+func (db *Database) Del(key string, id string) (err error) {
 	if db.pool == nil {
 		return errUninitialized
 	}
@@ -163,12 +170,12 @@ func (db *Database) Del(key string, id string) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // PDel deletes any entries matching the supplied pattern.
-func (db *Database) PDel(key string, pattern string) error {
-	var err error
+func (db *Database) PDel(key string, pattern string) (err error) {
 	if db.pool == nil {
 		return errUninitialized
 	}
@@ -177,12 +184,12 @@ func (db *Database) PDel(key string, pattern string) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // Expire sets or resets the timeout value on the requested entry.
-func (db *Database) Expire(key string, id string, seconds int) error {
-	var err error
+func (db *Database) Expire(key string, id string, seconds int) (err error) {
 	if db.pool == nil {
 		return errUninitialized
 	}
@@ -191,12 +198,12 @@ func (db *Database) Expire(key string, id string, seconds int) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // Persist removes the timeout value on the requested entry.
-func (db *Database) Persist(key string, id string) error {
-	var err error
+func (db *Database) Persist(key string, id string) (err error) {
 	if db.pool == nil {
 		return errUninitialized
 	}
@@ -205,60 +212,64 @@ func (db *Database) Persist(key string, id string) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // TTL returns the timeout value on the requested entry.
-func (db *Database) TTL(key string, id string) (float64, error) {
-	var err error
+func (db *Database) TTL(key string, id string) (ttl float64, err error) {
 	if db.pool == nil {
 		return 0, errUninitialized
 	}
 
-	var r *Response
-	r, err = db.runcmd("TTL", key, id)
+	r, err := db.runcmd("TTL", key, id)
 	if err != nil {
 		return 0, err
 	}
+
 	return r.TTL, nil
 }
 
 // runcmd runs a command against the database.
-func (db *Database) runcmd(cmd string, args ...string) (*Response, error) {
-	var err error
+func (db *Database) runcmd(cmd string, args ...string) (r *Response, err error) {
 	if args == nil {
 		return nil, errArgs
 	}
-	r := new(Response)
+
+	r = new(Response)
+
 	err = db.pool.Do(radix.Cmd(r, cmd, args...))
 	if err != nil {
 		return nil, err
 	}
+
 	if !r.Ok {
-		return nil, errors.New(r.Err)
+		return nil, fmt.Errorf("%w: %s", errResponse, r.Err)
 	}
+
 	return r, nil
 }
 
 // connectJSON creates a connection and sets the output mode to JSON.
-func connectJSON(net, addr string) (radix.Conn, error) {
-	var err error
-
-	var conn radix.Conn
+func connectJSON(net, addr string) (conn radix.Conn, err error) {
 	conn, err = radix.Dial(net, addr)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := new(Response)
+
 	err = conn.Do(radix.Cmd(resp, "OUTPUT", "json"))
 	if err != nil {
 		conn.Close()
+
 		return nil, err
 	}
+
 	if !resp.Ok {
 		conn.Close()
-		return nil, errors.New(resp.Err)
+
+		return nil, fmt.Errorf("%w: %s", errResponse, resp.Err)
 	}
 
 	return conn, nil

--- a/db_test.go
+++ b/db_test.go
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package t38c
+package t38c_test
 
 import (
 	"bytes"
@@ -35,32 +35,41 @@ import (
 	"time"
 
 	"github.com/tidwall/resp"
+	"kreklow.us/go/t38c"
 )
 
-var testT *testing.T
+//nolint:gochecknoglobals // to be refactored
+var (
+	testT *testing.T
 
-var testErrCmds = map[string][]interface{}{
-	"Set":     {"test", "obj1", "STRING", "testing"},
-	"Del":     {"test", "obj1"},
-	"PDel":    {"test", "obj*"},
-	"Expire":  {"test", "obj1", 60},
-	"Persist": {"test", "obj1"},
-}
+	testErrCmds = map[string][]interface{}{
+		"Set":     {"test", "obj1", "STRING", "testing"},
+		"Del":     {"test", "obj1"},
+		"PDel":    {"test", "obj*"},
+		"Expire":  {"test", "obj1", 60},
+		"Persist": {"test", "obj1"},
+	}
 
-var testRespErrCmds = map[string][]interface{}{
-	"Get":    {"test", "obj1"},
-	"Scan":   {"test"},
-	"Search": {"test"},
-}
+	testRespErrCmds = map[string][]interface{}{
+		"Get":    {"test", "obj1"},
+		"Scan":   {"test"},
+		"Search": {"test"},
+	}
+
+	testport    string
+	testsrvdata [][]byte
+	testsrv     *resp.Server
+	testdb      *t38c.Database
+)
 
 // TestUninitialized tests running functions on an uninitialized
 // Database object.
 func TestUninitialized(t *testing.T) {
-	db := new(Database)
+	db := new(t38c.Database)
 	errTxt := "database not initialized"
 
 	for c, a := range testErrCmds {
-		ai := reflectMethod(t, db, c, a...)
+		ai := reflectMethod(db, c, a...)
 		if len(ai) != 1 {
 			t.Errorf("%s: unexpected return values: %v\n", c, ai)
 		}
@@ -74,12 +83,12 @@ func TestUninitialized(t *testing.T) {
 	}
 
 	for c, a := range testRespErrCmds {
-		ai := reflectMethod(t, db, c, a...)
+		ai := reflectMethod(db, c, a...)
 		if len(ai) != 2 {
 			t.Errorf("%s: unexpected return values: %v\n", c, ai)
 		}
 
-		resp, ok := ai[0].(*Response)
+		resp, ok := ai[0].(*t38c.Response)
 		if !ok {
 			t.Errorf("%s: expected *Response, received %T\n", c, ai[0])
 		} else if resp != nil {
@@ -98,6 +107,7 @@ func TestUninitialized(t *testing.T) {
 	if err == nil || err.Error() != errTxt {
 		t.Errorf("TTL received: %s\nexpected: %s\n", err, errTxt)
 	}
+
 	if ttl != 0 {
 		t.Error("TTL received non-zero response with error")
 	}
@@ -108,22 +118,18 @@ func TestUninitialized(t *testing.T) {
 	}
 }
 
-var testport string
-var testsrvdata [][]byte
-var testsrv *resp.Server
-var testdb *Database
-
 // TestDBFunc tests database functions against a mock server.
-func TestDBFunc(t *testing.T) {
+func TestDBFunc(t *testing.T) { //nolint:funlen // to be refactored
 	// obtain random port
 	rand.Seed(time.Now().UnixNano())
-	testport = strconv.Itoa(rand.Intn(40000) + 10000)
+	testport = strconv.Itoa(rand.Intn(40000) + 10000) //nolint:gosec // not security related
 
 	// test connection failure
 	t.Run("ConnectFail", testConnectFail)
 
 	// start mock server on random port
 	testsrv = resp.NewServer()
+
 	go func() {
 		err := testsrv.ListenAndServe(net.JoinHostPort("127.0.0.1", testport))
 		if err != nil {
@@ -138,18 +144,23 @@ func TestDBFunc(t *testing.T) {
 
 	// test successful connection
 	testsrv.HandleFunc("OUTPUT", respReturnOKTrue)
+
 	testsrvdata = [][]byte{}
 	output := []byte("OUTPUT json")
-	db, err := Connect("127.0.0.1", testport, 1)
-	if db == nil {
-		t.Fatal("db returned nil")
-	}
+
+	db, err := t38c.Connect("127.0.0.1", testport, 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v\n", err)
 	}
+
+	if db == nil {
+		t.Fatal("db returned nil")
+	}
+
 	if len(testsrvdata) != 1 {
 		t.Fatalf("received %d values, expected 1\n", len(testsrvdata))
 	}
+
 	if !bytes.Equal(testsrvdata[0], []byte("OUTPUT json")) {
 		t.Fatalf("Received %s\nExpected: %s\n", testsrvdata, output)
 	}
@@ -167,41 +178,49 @@ func TestDBFunc(t *testing.T) {
 		t.Errorf("Set expected invalid arguments, received %v\n", err)
 	}
 
-	r, err := db.runcmd("test")
-	if err == nil || err.Error() != "invalid arguments" {
-		t.Errorf("runcmd expected invalid arguments, received %v\n", err)
-	}
-	if r != nil {
-		t.Errorf("runcmd expected nil, received response %v\n", r)
-	}
+	/*
+		r, err := db.runcmd("test")
+		if err == nil || err.Error() != "invalid arguments" {
+			t.Errorf("runcmd expected invalid arguments, received %v\n", err)
+		}
+		if r != nil {
+			t.Errorf("runcmd expected nil, received response %v\n", r)
+		}
+	*/
 
 	db.Close()
 }
 
-// test Connect with no server running
+// Test Connect with no server running.
 func testConnectFail(t *testing.T) {
-	db, err := Connect("127.0.0.1", testport, 1)
+	db, err := t38c.Connect("127.0.0.1", testport, 1)
 	if db != nil {
 		t.Error("db not nil on error")
 	}
+
 	if err == nil || !strings.Contains(err.Error(), "connection refused") {
 		t.Errorf("unexpected error received: %v\n", err)
 	}
 }
 
-// test Connect with error from server
+// Test Connect with error from server.
 func testConnectError(t *testing.T) {
 	output := []byte("OUTPUT json")
+
 	testsrv.HandleFunc("OUTPUT", respReturnErr)
+
 	testsrvdata = [][]byte{}
-	db, err := Connect("127.0.0.1", testport, 1)
+
+	db, err := t38c.Connect("127.0.0.1", testport, 1)
 	if db != nil {
 		t.Error("db not nil on error")
 	}
+
 	errTxt := "test server error"
 	if err == nil || err.Error() != errTxt {
 		t.Errorf("Received: %v\nExpected: %s\n", err, errTxt)
 	}
+
 	if len(testsrvdata) != 1 {
 		t.Errorf("Received %d values, expected 1\n", len(testsrvdata))
 	} else if !bytes.Equal(testsrvdata[0], output) {
@@ -209,19 +228,24 @@ func testConnectError(t *testing.T) {
 	}
 }
 
-// test Connect with false response from server
+// Test Connect with false response from server.
 func testConnectFalse(t *testing.T) {
 	output := []byte("OUTPUT json")
+
 	testsrv.HandleFunc("OUTPUT", respReturnOKFalse)
+
 	testsrvdata = [][]byte{}
-	db, err := Connect("127.0.0.1", testport, 1)
+
+	db, err := t38c.Connect("127.0.0.1", testport, 1)
 	if db != nil {
 		t.Error("db not nil on error")
 	}
-	errTxt := "test ok error"
+
+	errTxt := "received error: test ok error"
 	if err == nil || err.Error() != errTxt {
 		t.Errorf("Received: %v\nExpected: %s\n", err, errTxt)
 	}
+
 	if len(testsrvdata) != 1 {
 		t.Errorf("Received %d values, expected 1\n", len(testsrvdata))
 	} else if !bytes.Equal(testsrvdata[0], output) {
@@ -229,28 +253,35 @@ func testConnectFalse(t *testing.T) {
 	}
 }
 
-// test error responses
-func testCmdError(t *testing.T) {
+// Test error responses.
+func testCmdError(t *testing.T) { //nolint:funlen,gocognit,dupl // to be refactored
 	errTxt := "test server error"
+
 	for c, a := range testErrCmds {
 		testsrvdata = [][]byte{}
 		cmd := strings.ToUpper(c)
 		txtargs := []string{cmd}
+
 		for _, z := range a {
 			txtargs = append(txtargs, fmt.Sprintf("%v", z))
 		}
+
 		output := []byte(strings.Join(txtargs, " "))
+
 		testsrv.HandleFunc(cmd, respReturnErr)
-		ai := reflectMethod(t, testdb, c, a...)
+
+		ai := reflectMethod(testdb, c, a...)
 		if len(ai) != 1 {
 			t.Errorf("%s: unexpected return values: %v\n", c, ai)
 		}
+
 		err, ok := ai[0].(error)
 		if !ok {
 			t.Errorf("%s: expected error, received %T\n", c, ai[0])
 		} else if err.Error() != errTxt {
 			t.Errorf("%s: expected: %s\nreceived: %s\n", c, errTxt, err)
 		}
+
 		if len(testsrvdata) != 1 {
 			t.Errorf("%s: received %d values, expected 1\n", c, len(testsrvdata))
 		} else if !bytes.Equal(testsrvdata[0], output) {
@@ -262,27 +293,34 @@ func testCmdError(t *testing.T) {
 		testsrvdata = [][]byte{}
 		cmd := strings.ToUpper(c)
 		txtargs := []string{cmd}
+
 		for _, z := range a {
 			txtargs = append(txtargs, fmt.Sprintf("%v", z))
 		}
+
 		output := []byte(strings.Join(txtargs, " "))
+
 		testsrv.HandleFunc(cmd, respReturnErr)
-		ai := reflectMethod(t, testdb, c, a...)
+
+		ai := reflectMethod(testdb, c, a...)
 		if len(ai) != 2 {
 			t.Errorf("%s: unexpected return values: %v\n", c, ai)
 		}
-		resp, ok := ai[0].(*Response)
+
+		resp, ok := ai[0].(*t38c.Response)
 		if !ok {
 			t.Errorf("%s: expected *Response, received %T\n", c, ai[0])
 		} else if resp != nil {
 			t.Errorf("%s: received non-nil response: %v\n", c, resp)
 		}
+
 		err, ok := ai[1].(error)
 		if !ok {
 			t.Errorf("%s: expected error, received %T\n", c, ai[1])
 		} else if err.Error() != errTxt {
 			t.Errorf("%s: expected: %s\nreceived: %s\n", c, errTxt, err)
 		}
+
 		if len(testsrvdata) != 1 {
 			t.Errorf("%s: received %d values, expected 1\n", c, len(testsrvdata))
 		} else if !bytes.Equal(testsrvdata[0], output) {
@@ -292,14 +330,18 @@ func testCmdError(t *testing.T) {
 
 	testsrvdata = [][]byte{}
 	output := []byte("TTL test obj1")
+
 	testsrv.HandleFunc("TTL", respReturnErr)
+
 	ttl, err := testdb.TTL("test", "obj1")
 	if err == nil || err.Error() != errTxt {
 		t.Errorf("TTL received: %s\nexpected: %s\n", err, errTxt)
 	}
+
 	if ttl != 0 {
 		t.Error("TTL received non-zero response with error")
 	}
+
 	if len(testsrvdata) != 1 {
 		t.Errorf("TTL received %d values, expected 1\n", len(testsrvdata))
 	} else if !bytes.Equal(testsrvdata[0], output) {
@@ -307,28 +349,35 @@ func testCmdError(t *testing.T) {
 	}
 }
 
-// test false responses
-func testCmdFalse(t *testing.T) {
-	errTxt := "test ok error"
+// Test false responses.
+func testCmdFalse(t *testing.T) { //nolint:funlen,gocognit,dupl // to be refactored
+	errTxt := "received error: test ok error"
+
 	for c, a := range testErrCmds {
 		testsrvdata = [][]byte{}
 		cmd := strings.ToUpper(c)
 		txtargs := []string{cmd}
+
 		for _, z := range a {
 			txtargs = append(txtargs, fmt.Sprintf("%v", z))
 		}
+
 		output := []byte(strings.Join(txtargs, " "))
+
 		testsrv.HandleFunc(cmd, respReturnOKFalse)
-		ai := reflectMethod(t, testdb, c, a...)
+
+		ai := reflectMethod(testdb, c, a...)
 		if len(ai) != 1 {
 			t.Errorf("%s: unexpected return values: %v\n", c, ai)
 		}
+
 		err, ok := ai[0].(error)
 		if !ok {
 			t.Errorf("%s: expected error, received %T\n", c, ai[0])
 		} else if err.Error() != errTxt {
 			t.Errorf("%s: expected: %s\nreceived: %s\n", c, errTxt, err)
 		}
+
 		if len(testsrvdata) != 1 {
 			t.Errorf("%s: received %d values, expected 1\n", c, len(testsrvdata))
 		} else if !bytes.Equal(testsrvdata[0], output) {
@@ -340,27 +389,34 @@ func testCmdFalse(t *testing.T) {
 		testsrvdata = [][]byte{}
 		cmd := strings.ToUpper(c)
 		txtargs := []string{cmd}
+
 		for _, z := range a {
 			txtargs = append(txtargs, fmt.Sprintf("%v", z))
 		}
+
 		output := []byte(strings.Join(txtargs, " "))
+
 		testsrv.HandleFunc(cmd, respReturnOKFalse)
-		ai := reflectMethod(t, testdb, c, a...)
+
+		ai := reflectMethod(testdb, c, a...)
 		if len(ai) != 2 {
 			t.Errorf("%s: unexpected return values: %v\n", c, ai)
 		}
-		resp, ok := ai[0].(*Response)
+
+		resp, ok := ai[0].(*t38c.Response)
 		if !ok {
 			t.Errorf("%s: expected *Response, received %T\n", c, ai[0])
 		} else if resp != nil {
 			t.Errorf("%s: received non-nil response: %v\n", c, resp)
 		}
+
 		err, ok := ai[1].(error)
 		if !ok {
 			t.Errorf("%s: expected error, received %T\n", c, ai[1])
 		} else if err.Error() != errTxt {
 			t.Errorf("%s: expected: %s\nreceived: %s\n", c, errTxt, err)
 		}
+
 		if len(testsrvdata) != 1 {
 			t.Errorf("%s: received %d values, expected 1\n", c, len(testsrvdata))
 		} else if !bytes.Equal(testsrvdata[0], output) {
@@ -370,14 +426,18 @@ func testCmdFalse(t *testing.T) {
 
 	testsrvdata = [][]byte{}
 	output := []byte("TTL test obj1")
+
 	testsrv.HandleFunc("TTL", respReturnOKFalse)
+
 	ttl, err := testdb.TTL("test", "obj1")
 	if err == nil || err.Error() != errTxt {
 		t.Errorf("TTL received: %s\nexpected: %s\n", err, errTxt)
 	}
+
 	if ttl != 0 {
 		t.Error("TTL received non-zero response with error")
 	}
+
 	if len(testsrvdata) != 1 {
 		t.Errorf("TTL received %d values, expected 1\n", len(testsrvdata))
 	} else if !bytes.Equal(testsrvdata[0], output) {
@@ -385,27 +445,33 @@ func testCmdFalse(t *testing.T) {
 	}
 }
 
-// test success responses
-func testCmdSuccess(t *testing.T) {
+// Test success responses.
+func testCmdSuccess(t *testing.T) { //nolint:funlen,gocognit // to be refactored
 	for c, a := range testErrCmds {
 		testsrvdata = [][]byte{}
 		cmd := strings.ToUpper(c)
 		txtargs := []string{cmd}
+
 		for _, z := range a {
 			txtargs = append(txtargs, fmt.Sprintf("%v", z))
 		}
+
 		output := []byte(strings.Join(txtargs, " "))
+
 		testsrv.HandleFunc(cmd, respReturnOKTrue)
-		ai := reflectMethod(t, testdb, c, a...)
+
+		ai := reflectMethod(testdb, c, a...)
 		if len(ai) != 1 {
 			t.Errorf("%s: unexpected return values: %v\n", c, ai)
 		}
+
 		err, ok := ai[0].(error)
 		if !ok && ai[0] != nil {
 			t.Errorf("%s: expected error, received %T\n", c, ai[0])
 		} else if err != nil {
 			t.Errorf("%s: unexpected error: %v\n", c, err)
 		}
+
 		if len(testsrvdata) != 1 {
 			t.Errorf("%s: received %d values, expected 1\n", c, len(testsrvdata))
 		} else if !bytes.Equal(testsrvdata[0], output) {
@@ -417,27 +483,34 @@ func testCmdSuccess(t *testing.T) {
 		testsrvdata = [][]byte{}
 		cmd := strings.ToUpper(c)
 		txtargs := []string{cmd}
+
 		for _, z := range a {
 			txtargs = append(txtargs, fmt.Sprintf("%v", z))
 		}
+
 		output := []byte(strings.Join(txtargs, " "))
+
 		testsrv.HandleFunc(cmd, respReturnOKTrue)
-		ai := reflectMethod(t, testdb, c, a...)
+
+		ai := reflectMethod(testdb, c, a...)
 		if len(ai) != 2 {
 			t.Errorf("%s: unexpected return values: %v\n", c, ai)
 		}
-		resp, ok := ai[0].(*Response)
+
+		resp, ok := ai[0].(*t38c.Response)
 		if !ok {
 			t.Errorf("%s: expected *Response, received %T\n", c, ai[0])
 		} else if resp == nil {
 			t.Errorf("%s: received nil response\n", c)
 		}
+
 		err, ok := ai[1].(error)
 		if !ok && ai[1] != nil {
 			t.Errorf("%s: expected error, received %T\n", c, ai[1])
 		} else if err != nil {
 			t.Errorf("%s: unexpected error: %v\n", c, err)
 		}
+
 		if len(testsrvdata) != 1 {
 			t.Errorf("%s: received %d values, expected 1\n", c, len(testsrvdata))
 		} else if !bytes.Equal(testsrvdata[0], output) {
@@ -447,14 +520,18 @@ func testCmdSuccess(t *testing.T) {
 
 	testsrvdata = [][]byte{}
 	output := []byte("TTL test obj1")
+
 	testsrv.HandleFunc("TTL", respReturnOKTrue)
+
 	ttl, err := testdb.TTL("test", "obj1")
 	if err != nil {
 		t.Errorf("TTL unexpected error: %v\n", err)
 	}
+
 	if ttl != 5.67 {
 		t.Error("TTL received incorrect response")
 	}
+
 	if len(testsrvdata) != 1 {
 		t.Errorf("TTL received %d values, expected 1\n", len(testsrvdata))
 	} else if !bytes.Equal(testsrvdata[0], output) {
@@ -462,18 +539,23 @@ func testCmdSuccess(t *testing.T) {
 	}
 }
 
-// test Database.Get not found
+// Test Database.Get not found.
 func testGetNotFound(t *testing.T) {
 	output := []byte("GET test value1")
+
 	testsrv.HandleFunc("GET", respReturnOKNotFound)
+
 	testsrvdata = [][]byte{}
+
 	resp, err := testdb.Get("test", "value1")
 	if resp != nil {
 		t.Errorf("received unexpected response: %v\n", resp)
 	}
+
 	if err != nil {
 		t.Errorf("received unexpected error: %v\n", err)
 	}
+
 	if len(testsrvdata) != 1 {
 		t.Errorf("Received %d values, expected 1\n", len(testsrvdata))
 	} else if !bytes.Equal(testsrvdata[0], output) {
@@ -481,84 +563,112 @@ func testGetNotFound(t *testing.T) {
 	}
 }
 
-// server handler, returns error
+// Server handler, returns error.
 func respReturnErr(c *resp.Conn, args []resp.Value) bool {
 	var err error
+
 	var data []byte
+
 	for k, v := range args {
 		if k == 0 {
 			data = v.Bytes()
+
 			continue
 		}
+
 		data = bytes.Join([][]byte{data, v.Bytes()}, []byte(" "))
 	}
+
 	testsrvdata = append(testsrvdata, data)
-	err = c.WriteError(errors.New("test server error"))
+
+	err = c.WriteError(errors.New("test server error")) //nolint:goerr113 // ignore test error
 	if err != nil {
 		testT.Fatalf("internal write error: %s\n", err)
 	}
+
 	return true
 }
 
-// server handler, returns ok:false with an err string
+// Server handler, returns ok:false with an err string.
 func respReturnOKFalse(c *resp.Conn, args []resp.Value) bool {
 	var err error
+
 	var data []byte
+
 	for k, v := range args {
 		if k == 0 {
 			data = v.Bytes()
+
 			continue
 		}
+
 		data = bytes.Join([][]byte{data, v.Bytes()}, []byte(" "))
 	}
+
 	testsrvdata = append(testsrvdata, data)
+
 	err = c.WriteSimpleString(`{"ok":false,"err":"test ok error"}`)
 	if err != nil {
 		testT.Fatalf("internal write error: %s\n", err)
 	}
+
 	return true
 }
 
-// server handler, returns ok:false with a not found error
+// Server handler, returns ok:false with a not found error.
 func respReturnOKNotFound(c *resp.Conn, args []resp.Value) bool {
 	var err error
+
 	var data []byte
+
 	for k, v := range args {
 		if k == 0 {
 			data = v.Bytes()
+
 			continue
 		}
+
 		data = bytes.Join([][]byte{data, v.Bytes()}, []byte(" "))
 	}
+
 	testsrvdata = append(testsrvdata, data)
+
 	err = c.WriteSimpleString(`{"ok":false,"err":"id not found"}`)
 	if err != nil {
 		testT.Fatalf("internal write error: %s\n", err)
 	}
+
 	return true
 }
 
-// server handler, returns ok:true
+// Server handler, returns ok:true.
 func respReturnOKTrue(c *resp.Conn, args []resp.Value) bool {
 	var err error
+
 	var data []byte
+
 	for k, v := range args {
 		if k == 0 {
 			data = v.Bytes()
+
 			continue
 		}
+
 		data = bytes.Join([][]byte{data, v.Bytes()}, []byte(" "))
 	}
+
 	testsrvdata = append(testsrvdata, data)
+
 	err = c.WriteSimpleString(`{"ok":true, "object":"test", "ttl": 5.67}`)
 	if err != nil {
 		testT.Fatalf("internal write error: %s\n", err)
 	}
+
 	return true
 }
 
-// reflectMethod runs a method by reflection
-func reflectMethod(t *testing.T, db *Database, m string, arg ...interface{}) []interface{} {
+// reflectMethod runs a method by reflection.
+func reflectMethod(db *t38c.Database, m string, arg ...interface{}) []interface{} {
 	dbv := reflect.ValueOf(db)
 
 	va := make([]reflect.Value, len(arg))

--- a/response_test.go
+++ b/response_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Collin Kreklow
+// Copyright 2020 Collin Kreklow
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -20,122 +20,240 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package t38c
+package t38c_test
 
-import "testing"
+import (
+	"testing"
 
-// TestResponseInvalid simulates several error conditions
-func TestResponseInvalid(t *testing.T) {
-	var err error
-	r := new(Response)
-	err = r.UnmarshalText([]byte(`{invalid}`))
-	if err == nil || err.Error() != "received invalid JSON" {
-		t.Errorf("Received: %s\nExpected: received invalid JSON\n", err)
-	}
+	"kreklow.us/go/t38c"
+)
 
-	r = new(Response)
-	err = r.UnmarshalText([]byte(`{"zzz":true}`))
-	if err == nil || err.Error() != "unknown response value" {
-		t.Errorf("Received: %s\nExpected: unknown response value\n", err)
-	}
+// TestResponseErrors tests errors returned from Response.
+func TestResponseErrors(t *testing.T) {
+	t.Run("Invalid JSON", testResponseErrJSON)
+	t.Run("Unknown Value", testResponseErrValue)
+	t.Run("Unknown Type", testResponseErrType)
+}
 
-	r = new(Response)
-	err = r.UnmarshalText([]byte(`{"fields":true}`))
-	if err == nil || err.Error() != "unknown field type" {
-		t.Errorf("Received: %s\nExpected: unknown field type\n", err)
+func testResponseErrJSON(t *testing.T) {
+	json := []byte(`{invalid}`)
+	err := "received invalid JSON"
+
+	testResponseErr(t, json, err)
+}
+
+func testResponseErrValue(t *testing.T) {
+	json := []byte(`{"zzz": true}`)
+	err := "error decoding response: unknown response value"
+
+	testResponseErr(t, json, err)
+}
+
+func testResponseErrType(t *testing.T) {
+	json := []byte(`{"fields": true}`)
+	err := "error decoding response: unknown field type"
+
+	testResponseErr(t, json, err)
+}
+
+func testResponseErr(t *testing.T, json []byte, e string) {
+	r := new(t38c.Response)
+
+	err := r.UnmarshalText(json)
+	if err == nil {
+		tErrorStr(t, "UnmarshalText", "error", "nil")
+	} else if e != err.Error() {
+		tErrorStr(t, "UnmarshalText", e, err)
 	}
 }
 
-// TestResponseSingle simulates a single object GET
-func TestResponseSingle(t *testing.T) {
-	var err error
-	r := new(Response)
-	err = r.UnmarshalText([]byte(`{"ok":true,"object":{"type":"Point","coordinates":[0,0]},"fields":{"fY":999.999,"fZ":123},"elapsed":"100ms"}`))
-	if err != nil {
-		t.Errorf("Received unxpected error: %s\n", err)
-	}
-	if !r.Ok {
-		t.Error("Ok not true\n")
-	}
+// TestResponseValid tests valid Responses.
+func TestResponseValid(t *testing.T) {
+	t.Run("Single JSON", testResponseSingleJSON)
+	t.Run("Single String", testResponseSingleString)
+	t.Run("Multiple Objects", testResponseMultObj)
+	t.Run("Multiple IDs", testResponseMultID)
+	t.Run("Geofence", testResponseFence)
+	t.Run("Server Error", testResponseSrvErr)
+}
+
+func testResponseSingleJSON(t *testing.T) {
+	json := []byte(`{"ok":true,"object":{"type":"Point","coordinates":[0,0]},"fields":{"fY":999.999,"fZ":123},"ttl":500,"elapsed":"100ms"}`)
 	obj := `{"type":"Point","coordinates":[0,0]}`
-	if r.Object != obj {
-		t.Errorf("Received: %s\nExpected: %s\n", r.Object, obj)
+
+	testResponseSingle(t, json, obj)
+}
+
+func testResponseSingleString(t *testing.T) {
+	json := []byte(`{"ok":true,"object":"objstr","fields":{"fY":999.999,"fZ":123},"ttl":500,"elapsed":"100ms"}`)
+	obj := `objstr`
+
+	testResponseSingle(t, json, obj)
+}
+
+func testResponseSingle(t *testing.T, json []byte, obj string) {
+	r := new(t38c.Response)
+
+	err := r.UnmarshalText(json)
+	if err != nil {
+		tFatalErr(t, "UnmarshalText", err)
 	}
+
+	if !r.Ok {
+		tErrorStr(t, "Ok", "true", "false")
+	}
+
+	if r.Object != obj {
+		tErrorStr(t, "Object", obj, r.Object)
+	}
+
 	fields := map[string]float64{
 		"fY": 999.999,
 		"fZ": 123,
 	}
 	for k, v := range r.FieldNames {
 		if r.FieldValues[v] != fields[k] {
-			t.Errorf("Received %s: %f\nExpected: %f\n", k, r.FieldValues[v], fields[k])
+			tErrorVal(t, k, fields[k], r.FieldValues[v])
 		}
 	}
-	if r.Elapsed != "100ms" {
-		t.Errorf("Received: %s\nExpected: %s\n", r.Elapsed, "100ms")
+
+	expTTL := float64(500)
+	if r.TTL != expTTL {
+		tErrorVal(t, "TTL", expTTL, r.TTL)
+	}
+
+	expElapsed := "100ms"
+	if r.Elapsed != expElapsed {
+		tErrorStr(t, "Elapsed", expElapsed, r.Elapsed)
 	}
 }
 
-// TestResponseMultiple simulates a multiple object SCAN
-func TestResponseMultiple(t *testing.T) {
-	var err error
-	r := new(Response)
-	err = r.UnmarshalText([]byte(`{"ok":true,"fields":["fZ","fY"],"objects":[{"id":"value1","object":{"type":"Point","coordinates":[0,0]},"fields":[123,999]},{"id":"value2","object":{"type":"Point","coordinates":[45,45]},"fields":[0,456]}],"count":2,"cursor":1,"elapsed":"567.89µs"}`))
-	if err != nil {
-		t.Errorf("Received unxpected error: %s\n", err)
-	}
-	if !r.Ok {
-		t.Error("Ok not true\n")
-	}
+func testResponseMultObj(t *testing.T) {
+	json := []byte(`{"ok":true,"fields":["fZ","fY"],"objects":[{"id":"value1","object":{"type":"Point","coordinates":[0,0]},"fields":[123,999]},{"id":"value2","object":{"type":"Point","coordinates":[45,45]},"fields":[0,456]}],"count":2,"cursor":0,"elapsed":"567.89µs"}`)
 	objs := []string{
 		`{"id":"value1","object":{"type":"Point","coordinates":[0,0]},"fields":[123,999]}`,
 		`{"id":"value2","object":{"type":"Point","coordinates":[45,45]},"fields":[0,456]}`,
 	}
-	if r.Objects[0] != objs[0] {
-		t.Errorf("Received: %s\nExpected: %s\n", r.Objects[0], objs[0])
-	}
-	if r.Objects[1] != objs[1] {
-		t.Errorf("Received: %s\nExpected: %s\n", r.Objects[1], objs[1])
-	}
-	if r.Count != 2 {
-		t.Errorf("Received: %d\nExpected: %d\n", r.Count, 2)
-	}
-	if r.Cursor != 1 {
-		t.Errorf("Received: %d\nExpected: %d\n", r.Cursor, 1)
-	}
-	if r.Elapsed != "567.89µs" {
-		t.Errorf("Received: %s\nExpected: %s\n", r.Elapsed, "567.89µs")
+
+	testResponseMult(t, json, objs, nil)
+}
+
+func testResponseMultID(t *testing.T) {
+	json := []byte(`{"ok":true,"ids":["value1","value2"],"count":2,"cursor":0,"elapsed":"567.89µs"}`)
+	ids := []string{"value1", "value2"}
+
+	testResponseMult(t, json, nil, ids)
+}
+
+func testResponseMult(t *testing.T, json []byte, objs []string, ids []string) {
+	r := new(t38c.Response)
+
+	err := r.UnmarshalText(json)
+	if err != nil {
+		tFatalErr(t, "UnmarshalText", err)
 	}
 
-	r = new(Response)
-	err = r.UnmarshalText([]byte(`{"ok":true,"ids":["value1","value2"],"count":2,"cursor":0,"elapsed":"1.7s"}`))
-	if err != nil {
-		t.Errorf("Received unxpected error: %s\n", err)
+	if !r.Ok {
+		tErrorStr(t, "Ok", "true", "false")
 	}
-	if r.IDs[0] != "value1" {
-		t.Errorf("Received: %s\nExpected: %s\n", r.IDs[0], "value1")
+
+	if objs != nil {
+		if len(r.Objects) < 2 {
+			t.Fatal("not enough objects returned")
+		}
+
+		if r.Objects[0] != objs[0] {
+			tErrorStr(t, "Object 0", objs[0], r.Objects[0])
+		}
+
+		if r.Objects[1] != objs[1] {
+			tErrorStr(t, "Object 1", objs[1], r.Objects[1])
+		}
 	}
-	if r.IDs[1] != "value2" {
-		t.Errorf("Received: %s\nExpected: %s\n", r.IDs[1], "value2")
+
+	if ids != nil {
+		if len(r.IDs) < 2 {
+			t.Fatal("not enough IDs returned")
+		}
+
+		if r.IDs[0] != ids[0] {
+			tErrorStr(t, "ID 0", ids[0], r.IDs[0])
+		}
+
+		if r.IDs[1] != ids[1] {
+			tErrorStr(t, "ID 1", ids[1], r.IDs[1])
+		}
+	}
+
+	expCount := int64(2)
+	if r.Count != expCount {
+		tErrorVal(t, "Count", expCount, r.Count)
+	}
+
+	expCursor := int64(0)
+	if r.Cursor != expCursor {
+		tErrorVal(t, "Cursor", expCursor, r.Cursor)
+	}
+
+	expElapsed := "567.89µs"
+	if r.Elapsed != expElapsed {
+		tErrorVal(t, "Elapsed", expElapsed, r.Elapsed)
 	}
 }
 
-// TestResponseFence simulates receiving messages from a live geofence
-func TestResponseFence(t *testing.T) {
-	var err error
+func testResponseFence(t *testing.T) {
 	msgs := [][]byte{
 		[]byte(`{"ok":true,"live":true}`),
 		[]byte(`{"command":"set","group":"5b844beb0a1c1f009ac75639","detect":"enter","key":"test","time":"2018-08-27T19:07:23.578553343Z","id":"value3","object":{"type":"Point","coordinates":[30,30,800]},"fields":{}}`),
 		[]byte(`{"command":"set","group":"5b844beb0a1c1f009ac75639","detect":"inside","key":"test","time":"2018-08-27T19:07:23.578553343Z","id":"value3","object":{"type":"Point","coordinates":[30,30,800]},"fields":{}}`),
 		[]byte(`{"command":"del","id":"value3","time":"2018-08-27T19:07:33.671191005Z"}`),
 	}
+
 	for _, m := range msgs {
-		var r = new(Response)
-		err = r.UnmarshalText(m)
+		r := new(t38c.Response)
+
+		err := r.UnmarshalText(m)
 		if err != nil {
-			t.Errorf("Received unxpected error: %s\n", err)
+			tFatalErr(t, "UnmarshalText", err)
 		}
+
 		if !r.Ok && r.Command == "" {
-			t.Error("Ok not true and Command not populated\n")
+			t.Error("Ok not true and Command not populated")
 		}
 	}
+}
+
+func testResponseSrvErr(t *testing.T) {
+	json := []byte(`{"ok":true,"err":"bad request"}`)
+
+	r := new(t38c.Response)
+
+	err := r.UnmarshalText(json)
+	if err != nil {
+		tFatalErr(t, "UnmarshalText", err)
+	}
+
+	if !r.Ok {
+		tErrorStr(t, "Ok", "true", "false")
+	}
+
+	expErr := "bad request"
+	if expErr != r.Err {
+		tErrorStr(t, "Err", expErr, r.Err)
+	}
+}
+
+func tFatalErr(t *testing.T, desc string, err error) { //nolint:unparam // future use
+	t.Helper()
+	t.Fatalf("%s: received unexpected error: %s", desc, err)
+}
+
+func tErrorStr(t *testing.T, desc string, exp interface{}, act interface{}) {
+	t.Helper()
+	t.Errorf("%s: expected %s | received %s", desc, exp, act)
+}
+
+func tErrorVal(t *testing.T, desc string, exp interface{}, act interface{}) {
+	t.Helper()
+	t.Errorf("%s: expected %v | received %v", desc, exp, act)
 }


### PR DESCRIPTION
Significantly cleaned up formatting and refactored code using golangci-lint.

Added configuration for running CI lint against PRs